### PR TITLE
Make the created buffer reusable in skip ChannelInput

### DIFF
--- a/src/main/java/com/intel/chimera/input/ChannelInput.java
+++ b/src/main/java/com/intel/chimera/input/ChannelInput.java
@@ -26,7 +26,7 @@ import java.nio.channels.ReadableByteChannel;
  * wraps it as <code>Input</code> object acceptable by <code>CryptoInputStream</code>.
  */
 public class ChannelInput implements Input {
-  private static final int MAX_SKIP_BUFFER_SIZE = 2048;
+  private static final int SKIP_BUFFER_SIZE = 2048;
 
   private ByteBuffer buf;
   private ReadableByteChannel channel;
@@ -50,7 +50,7 @@ public class ChannelInput implements Input {
       return 0;
     }
 
-    int size = (int)Math.min(MAX_SKIP_BUFFER_SIZE, remaining);
+    int size = (int)Math.min(SKIP_BUFFER_SIZE, remaining);
     ByteBuffer skipBuffer = getSkipBuf();
     while (remaining > 0) {
       skipBuffer.clear();
@@ -77,7 +77,7 @@ public class ChannelInput implements Input {
 
   private ByteBuffer getSkipBuf() {
     if (buf == null) {
-      buf = ByteBuffer.allocate(MAX_SKIP_BUFFER_SIZE);
+      buf = ByteBuffer.allocate(SKIP_BUFFER_SIZE);
     }
     return buf;
   }

--- a/src/main/java/com/intel/chimera/input/ChannelInput.java
+++ b/src/main/java/com/intel/chimera/input/ChannelInput.java
@@ -28,6 +28,7 @@ import java.nio.channels.ReadableByteChannel;
 public class ChannelInput implements Input {
   private static final int MAX_SKIP_BUFFER_SIZE = 2048;
 
+  private ByteBuffer buf;
   private ReadableByteChannel channel;
 
   public ChannelInput(
@@ -50,7 +51,7 @@ public class ChannelInput implements Input {
     }
 
     int size = (int)Math.min(MAX_SKIP_BUFFER_SIZE, remaining);
-    ByteBuffer skipBuffer = ByteBuffer.allocate(size);
+    ByteBuffer skipBuffer = getSkipBuf();
     while (remaining > 0) {
       skipBuffer.clear();
       skipBuffer.limit((int)Math.min(size, remaining));
@@ -72,5 +73,12 @@ public class ChannelInput implements Input {
   @Override
   public void close() throws IOException {
     channel.close();
+  }
+
+  private ByteBuffer getSkipBuf() {
+    if (buf == null) {
+      buf = ByteBuffer.allocate(MAX_SKIP_BUFFER_SIZE);
+    }
+    return buf;
   }
 }


### PR DESCRIPTION
Addressing @jerrychenhf comments in another [PR8](https://github.com/intel-hadoop/chimera/pull/8).