### PR TITLE
Fix PKCS5Padding of openssl

### DIFF
--- a/src/main/java/com/intel/chimera/cipher/CipherTransformation.java
+++ b/src/main/java/com/intel/chimera/cipher/CipherTransformation.java
@@ -24,7 +24,7 @@ package com.intel.chimera.cipher;
 public enum CipherTransformation {
   AES_CTR_NOPADDING("AES/CTR/NoPadding", 16),
   AES_CBC_NOPADDING("AES/CBC/NoPadding", 16),
-  AES_CBC_PKCS5PADDING("AES/CBC/PKCS5PADDING", 16);
+  AES_CBC_PKCS5PADDING("AES/CBC/PKCS5Padding", 16);
 
   private final String name;
   private final int algorithmBlockSize;

--- a/src/main/java/com/intel/chimera/cipher/Openssl.java
+++ b/src/main/java/com/intel/chimera/cipher/Openssl.java
@@ -61,7 +61,8 @@ public final class Openssl {
   }
 
   private static enum Padding {
-    NoPadding;
+    NoPadding,
+    PKCS5Padding;
 
     static int get(String padding) throws NoSuchPaddingException {
       try {

--- a/src/main/native/com/intel/chimera/cipher/OpensslNative.c
+++ b/src/main/native/com/intel/chimera/cipher/OpensslNative.c
@@ -80,7 +80,7 @@ static __dlsym_EVP_aes_128_cbc dlsym_EVP_aes_128_cbc;
 static HMODULE openssl;
 #endif
 
-static void loadAesCtr(JNIEnv *env)
+static void loadAes(JNIEnv *env)
 {
 #ifdef UNIX
   LOAD_DYNAMIC_SYMBOL(dlsym_EVP_aes_256_ctr, env, openssl, "EVP_aes_256_ctr");
@@ -167,7 +167,7 @@ JNIEXPORT void JNICALL Java_com_intel_chimera_cipher_OpensslNative_initIDs
                       env, openssl, "EVP_CipherFinal_ex");
 #endif
 
-  loadAesCtr(env);
+  loadAes(env);
   jthrowable jthr = (*env)->ExceptionOccurred(env);
   if (jthr) {
     (*env)->DeleteLocalRef(env, jthr);
@@ -288,6 +288,8 @@ JNIEXPORT jlong JNICALL Java_com_intel_chimera_cipher_OpensslNative_init
 
   if (padding == NOPADDING) {
     dlsym_EVP_CIPHER_CTX_set_padding(context, 0);
+  } else if (padding == PKCS5PADDING) {
+    dlsym_EVP_CIPHER_CTX_set_padding(context, 1);
   }
 
   return JLONG(context);

--- a/src/test/java/com/intel/chimera/cipher/AbstractCipherTest.java
+++ b/src/test/java/com/intel/chimera/cipher/AbstractCipherTest.java
@@ -24,6 +24,7 @@ import java.util.Properties;
 import javax.xml.bind.DatatypeConverter;
 
 import com.intel.chimera.conf.ConfigurationKeys;
+import com.intel.chimera.utils.ReflectionUtils;
 import com.intel.chimera.utils.Utils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -73,7 +74,7 @@ public abstract class AbstractCipherTest {
     }
   }
 
-  private void byteBufferTest(CipherTransformation transformation,byte[] key,
+  private void byteBufferTest(CipherTransformation transformation, byte[] key,
                               byte[] iv,
                                 ByteBuffer input, ByteBuffer output) throws
       GeneralSecurityException, IOException {
@@ -81,8 +82,8 @@ public abstract class AbstractCipherTest {
     ByteBuffer encResult = ByteBuffer.allocateDirect(BYTEBUFFER_SIZE);
     Cipher enc, dec;
 
-    enc = CipherFactory.getInstance(transformation, props);
-    dec = CipherFactory.getInstance(transformation, props);
+    enc = getCipher(transformation);
+    dec = getCipher(transformation);
 
     try {
       enc.init(Cipher.ENCRYPT_MODE, key, iv);
@@ -126,5 +127,16 @@ public abstract class AbstractCipherTest {
       decResult.get(decResultArray);
       Assert.fail();
     }
+  }
+
+  private Cipher getCipher(CipherTransformation transformation) {
+    try {
+      return (Cipher) ReflectionUtils
+          .newInstance(ReflectionUtils.getClassByName(cipherClass), props,
+              transformation);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+
   }
 }


### PR DESCRIPTION
Fix PKCS5Padding of openssl, and use `ReflectionUtils` create the cipher instance since `CipherFactory` will use JCECipher when the real cipher created failed